### PR TITLE
Set project name for CI build

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "spring-composed"


### PR DESCRIPTION
This change will allow me to deploy properly spring-composed JAR on repo.spring.io.
