### PR TITLE
Introduce annotation for exclusion from component scanning

### DIFF
--- a/src/main/java/org/springframework/composed/context/ExcludeFromScan.java
+++ b/src/main/java/org/springframework/composed/context/ExcludeFromScan.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.composed.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An ExcludeFromScan annotation is used on Spring's {@link org.springframework.context.annotation.Configuration
+ * Configuration} classes to exclude those from Springs component scan mechanism.
+ * <p/>
+ * Some application that defines the {@link org.springframework.context.annotation.ComponentScan ComponentScan}
+ * annotation may define a filter that excludes all types annotated with {@link ExcludeFromScan}.
+ *
+ * Example:
+ * <pre>
+ *     @ComponentScan(excludeFilters = @ComponentScan.Filter(ExcludeFromScan.class))
+ * </pre>
+ *
+ * @author <a href="mailto:scherrer@openwms.org">Heiko Scherrer</a>
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ExcludeFromScan {
+}


### PR DESCRIPTION
The need to have a marker annotation to exclude `@Configuration` classes from `@ComponentScan`. For example one is writing framework code, based on Spring, and wants to exclude custom types from Spring's component scan mechanism. The caller can put this marker annotation on `@Configuration` classes to filter those annotated types. Pro: No need to implement `org.springframework.context.annotation.ImportSelector`. Cons: Caller has to add a filter to `@ComponentScan` explicitly
